### PR TITLE
feat: Add git config command

### DIFF
--- a/src/commands/git/config.ts
+++ b/src/commands/git/config.ts
@@ -1,0 +1,63 @@
+import {Command, flags} from '@oclif/command'
+import {execSync} from 'child_process'
+import * as fs from 'fs'
+import * as path from 'path'
+
+type RcmTag = 'personal' | 'work'
+const SIGNING_KEY_REGEX = /^\s+signingkey = ([A-F0-9]+)$/gm
+const EMAIL_REGEX = /^\s+email = (([a-zA-Z0-9_\-\.]+)@([a-zA-Z0-9_\-\.]+)\.([a-zA-Z]{2,5}))$/gm
+const NAME_REGEX = /^\s+name = ([a-zA-Z ]+)$/gm
+
+export default class Config extends Command {
+  static description = 'Commands for git config'
+
+  static examples = [
+    '$ clo git config --signing=personal',
+  ]
+
+  static flags = {
+    help: flags.help({char: 'h'}),
+    signingKey: flags.string({
+      char: 's',
+      description: 'rcm tag to use for signingkey',
+      options: ['personal', 'work'],
+      required: true
+    })
+  }
+
+  async run() {
+    let {flags} = this.parse(Config)
+    let rcmTag = flags.signingKey as RcmTag
+    let commands = [
+      `git config --local user.name "${this.name(rcmTag)}"`,
+      `git config --local user.email "${this.email(rcmTag)}"`,
+      `git config --local user.signingkey ${this.signingKey(rcmTag)}`,
+    ]
+
+    commands.map(command => {
+      this.log(command)
+      execSync(command)
+    })
+  }
+
+  signingKey(tag: RcmTag) {
+    let gitConfigLocalPath = path.join(this.config.home, '.dotfiles', `tag-${tag}`, 'gitconfig.local')
+    let gitConfigLocal = fs.readFileSync(gitConfigLocalPath, {encoding: 'utf8'})
+    let signingKeyResult = SIGNING_KEY_REGEX.exec(gitConfigLocal)
+    return signingKeyResult ? signingKeyResult[1] : null
+  }
+
+  email(tag: RcmTag) {
+    let gitConfigLocalPath = path.join(this.config.home, '.dotfiles', `tag-${tag}`, 'gitconfig')
+    let gitConfigLocal = fs.readFileSync(gitConfigLocalPath, {encoding: 'utf8'})
+    let emailResult = EMAIL_REGEX.exec(gitConfigLocal)
+    return emailResult ? emailResult[1] : null
+  }
+
+  name(tag: RcmTag) {
+    let gitConfigLocalPath = path.join(this.config.home, '.dotfiles', `tag-${tag}`, 'gitconfig')
+    let gitConfigLocal = fs.readFileSync(gitConfigLocalPath, {encoding: 'utf8'})
+    let name = NAME_REGEX.exec(gitConfigLocal)
+    return name ? name[1] : null
+  }
+}

--- a/src/commands/git/config.ts
+++ b/src/commands/git/config.ts
@@ -8,11 +8,12 @@ const SIGNING_KEY_REGEX = /^\s+signingkey = ([A-F0-9]+)$/gm
 const EMAIL_REGEX = /^\s+email = (([a-zA-Z0-9_\-\.]+)@([a-zA-Z0-9_\-\.]+)\.([a-zA-Z]{2,5}))$/gm
 const NAME_REGEX = /^\s+name = ([a-zA-Z ]+)$/gm
 
-export default class Config extends Command {
+export default class GitConfig extends Command {
   static description = 'Commands for git config'
 
   static examples = [
-    '$ clo git config --signing=personal',
+    '$ clo git:config --signingKey=personal',
+    '$ clo git:config -s work',
   ]
 
   static flags = {
@@ -26,7 +27,7 @@ export default class Config extends Command {
   }
 
   async run() {
-    let {flags} = this.parse(Config)
+    let {flags} = this.parse(GitConfig)
     let rcmTag = flags.signingKey as RcmTag
     let commands = [
       `git config --local user.name "${this.name(rcmTag)}"`,

--- a/test/commands/git/config.test.ts
+++ b/test/commands/git/config.test.ts
@@ -1,0 +1,80 @@
+import * as Config from '@oclif/config'
+import {expect, test} from '@oclif/test'
+import {loadConfig} from '@oclif/test/lib/load-config'
+import * as childProcess from 'child_process'
+import * as fs from 'fs'
+import * as sinon from 'sinon'
+
+import GitConfig from '../../../src/commands/git/config'
+
+let config: Config.IConfig
+let sandbox = sinon.sandbox.create()
+let readFileSyncStub: sinon.SinonStub
+let childProcessStub: sinon.SinonStub
+let cmd: GitConfig
+
+describe('run', () => {
+  beforeEach(async () => {
+    config = await Config.load(loadConfig.root)
+    sandbox.stub(config, 'home').value('/Users/jacopastorius')
+    readFileSyncStub = sandbox.stub(fs, 'readFileSync')
+    childProcessStub = sandbox.stub(childProcess, 'execSync')
+    cmd = new GitConfig([], config)
+    readFileSyncStub.withArgs('/Users/jacopastorius/.dotfiles/tag-personal/gitconfig').returns(`[user]\n
+  name = Jaco Pastorius\n
+  email = jaco@jacopastorius.com\n
+`)
+    readFileSyncStub.withArgs('/Users/jacopastorius/.dotfiles/tag-personal/gitconfig.local').returns(`[user]\n
+  signingkey = F0F8FCB77612188F\n
+`)
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  test
+    .stdout()
+    .command(['git:config', '--signing', 'personal'])
+    .it('edits local git user config for an rcm tag', () => {
+      expect(childProcessStub.calledWith('git config --local user.name "Jaco Pastorius"')).equal(true)
+      expect(childProcessStub.calledWith('git config --local user.email "jaco@jacopastorius.com"')).equal(true)
+      expect(childProcessStub.calledWith('git config --local user.signingkey "F0F8FCB77612188F')).equal(true)
+    })
+})
+
+describe('user config', () => {
+  beforeEach(async () => {
+    config = await Config.load(loadConfig.root)
+    sandbox.stub(config, 'home').value('/Users/jacopastorius')
+    readFileSyncStub = sandbox.stub(fs, 'readFileSync')
+    cmd = new GitConfig([], config)
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  it('gets the signing key from a gitconfig.local for a tag', () => {
+    readFileSyncStub.withArgs('/Users/jacopastorius/.dotfiles/tag-personal/gitconfig.local').returns(`[user]\n
+  signingkey = F0F8FCB77612188F\n
+`)
+    expect(cmd.signingKey('personal')).equals('F0F8FCB77612188F')
+  })
+
+  it('gets the email from a gitconfig for a tag', () => {
+    readFileSyncStub.withArgs('/Users/jacopastorius/.dotfiles/tag-personal/gitconfig').returns(`[user]\n
+  name = Jaco Pastorius\n
+  email = jaco@jacopastorius.com\n
+`)
+    expect(cmd.email('personal')).equals('jaco@jacopastorius.com')
+  })
+
+  it('gets the name from a gitconfig for a tag', () => {
+    readFileSyncStub.withArgs('/Users/jacopastorius/.dotfiles/tag-personal/gitconfig').returns(`[user]\n
+  name = Jaco Pastorius\n
+  email = jaco@jacopastorius.com\n
+`)
+    expect(cmd.name('personal')).equals('Jaco Pastorius')
+  })
+})

--- a/test/commands/git/config.test.ts
+++ b/test/commands/git/config.test.ts
@@ -47,7 +47,6 @@ describe('git:config', () => {
 
   it('gets the signing key from a gitconfig.local for a tag', () => {
     expect(cmd.signingKey('personal')).equals('F0F8FCB77612188F')
-    // expect(cmd.signingKey('personal')).equals('F0F8FCB77612188F')
   })
 
   it('gets the email from a gitconfig for a tag', () => {

--- a/test/commands/git/config.test.ts
+++ b/test/commands/git/config.test.ts
@@ -1,5 +1,5 @@
 import * as Config from '@oclif/config'
-import {expect, test} from '@oclif/test'
+import {expect} from '@oclif/test'
 import {loadConfig} from '@oclif/test/lib/load-config'
 import * as childProcess from 'child_process'
 import * as fs from 'fs'
@@ -7,74 +7,54 @@ import * as sinon from 'sinon'
 
 import GitConfig from '../../../src/commands/git/config'
 
-let config: Config.IConfig
-let sandbox = sinon.sandbox.create()
-let readFileSyncStub: sinon.SinonStub
-let childProcessStub: sinon.SinonStub
-let cmd: GitConfig
+describe('git:config', () => {
+  let config: Config.IConfig
+  let sandbox: sinon.SinonSandbox
+  let readFileSyncStub: sinon.SinonStub
+  let childProcessStub: sinon.SinonStub
+  let cmd: GitConfig
+  let gitConfig = `[user]\n
+  name = Jaco Pastorius\n
+  email = jaco@jacopastorius.com\n
+`
+  let gitConfigLocal = `[user]\n
+  signingkey = F0F8FCB77612188F\n
+`
 
-describe('run', () => {
   beforeEach(async () => {
+    sandbox = sinon.createSandbox()
     config = await Config.load(loadConfig.root)
     sandbox.stub(config, 'home').value('/Users/jacopastorius')
     readFileSyncStub = sandbox.stub(fs, 'readFileSync')
     childProcessStub = sandbox.stub(childProcess, 'execSync')
-    cmd = new GitConfig([], config)
-    readFileSyncStub.withArgs('/Users/jacopastorius/.dotfiles/tag-personal/gitconfig').returns(`[user]\n
-  name = Jaco Pastorius\n
-  email = jaco@jacopastorius.com\n
-`)
-    readFileSyncStub.withArgs('/Users/jacopastorius/.dotfiles/tag-personal/gitconfig.local').returns(`[user]\n
-  signingkey = F0F8FCB77612188F\n
-`)
-  })
-
-  afterEach(() => {
-    sandbox.restore()
-  })
-
-  test
-    .stdout()
-    .command(['git:config', '--signing', 'personal'])
-    .it('edits local git user config for an rcm tag', () => {
-      expect(childProcessStub.calledWith('git config --local user.name "Jaco Pastorius"')).equal(true)
-      expect(childProcessStub.calledWith('git config --local user.email "jaco@jacopastorius.com"')).equal(true)
-      expect(childProcessStub.calledWith('git config --local user.signingkey "F0F8FCB77612188F')).equal(true)
-    })
-})
-
-describe('user config', () => {
-  beforeEach(async () => {
-    config = await Config.load(loadConfig.root)
-    sandbox.stub(config, 'home').value('/Users/jacopastorius')
-    readFileSyncStub = sandbox.stub(fs, 'readFileSync')
+    readFileSyncStub.withArgs('/Users/jacopastorius/.dotfiles/tag-personal/gitconfig').returns([gitConfig, gitConfig])
+    readFileSyncStub.withArgs('/Users/jacopastorius/.dotfiles/tag-personal/gitconfig.local').returns([gitConfigLocal, gitConfigLocal])
+    readFileSyncStub.callThrough()
     cmd = new GitConfig([], config)
   })
 
   afterEach(() => {
     sandbox.restore()
+  })
+
+  it('edits local git user config for an rcm tag', () => {
+    cmd.argv = ['--signingKey', 'personal']
+    cmd.run()
+    expect(childProcessStub.calledWith('git config --local user.name "Jaco Pastorius"')).equal(true)
+    expect(childProcessStub.calledWith('git config --local user.email "jaco@jacopastorius.com"')).equal(true)
+    expect(childProcessStub.calledWith('git config --local user.signingkey F0F8FCB77612188F')).equal(true)
   })
 
   it('gets the signing key from a gitconfig.local for a tag', () => {
-    readFileSyncStub.withArgs('/Users/jacopastorius/.dotfiles/tag-personal/gitconfig.local').returns(`[user]\n
-  signingkey = F0F8FCB77612188F\n
-`)
     expect(cmd.signingKey('personal')).equals('F0F8FCB77612188F')
+    // expect(cmd.signingKey('personal')).equals('F0F8FCB77612188F')
   })
 
   it('gets the email from a gitconfig for a tag', () => {
-    readFileSyncStub.withArgs('/Users/jacopastorius/.dotfiles/tag-personal/gitconfig').returns(`[user]\n
-  name = Jaco Pastorius\n
-  email = jaco@jacopastorius.com\n
-`)
     expect(cmd.email('personal')).equals('jaco@jacopastorius.com')
   })
 
   it('gets the name from a gitconfig for a tag', () => {
-    readFileSyncStub.withArgs('/Users/jacopastorius/.dotfiles/tag-personal/gitconfig').returns(`[user]\n
-  name = Jaco Pastorius\n
-  email = jaco@jacopastorius.com\n
-`)
     expect(cmd.name('personal')).equals('Jaco Pastorius')
   })
 })

--- a/test/commands/vs.test.ts
+++ b/test/commands/vs.test.ts
@@ -25,7 +25,6 @@ describe('run', () => {
 
   afterEach(() => {
     sandbox.restore()
-    childProcessStub.restore()
   })
 
   it('opens the current directory if no name is specified', () => {

--- a/test/commands/vs.test.ts
+++ b/test/commands/vs.test.ts
@@ -13,7 +13,7 @@ let fsStub: sinon.SinonStub
 let childProcessStub: sinon.SinonStub
 let cmd: Vs
 
-describe('target', () => {
+describe('run', () => {
   beforeEach(async () => {
     config = await Config.load(loadConfig.root)
     sandbox.stub(config, 'home').value('/Users/jacopastorius')

--- a/test/commands/vs.test.ts
+++ b/test/commands/vs.test.ts
@@ -7,14 +7,15 @@ import * as sinon from 'sinon'
 
 import Vs from '../../src/commands/vs'
 
-let config: Config.IConfig
-let sandbox = sinon.sandbox.create()
-let fsStub: sinon.SinonStub
-let childProcessStub: sinon.SinonStub
-let cmd: Vs
-
 describe('run', () => {
+  let config: Config.IConfig
+  let sandbox: sinon.SinonSandbox
+  let fsStub: sinon.SinonStub
+  let childProcessStub: sinon.SinonStub
+  let cmd: Vs
+
   beforeEach(async () => {
+    sandbox = sinon.createSandbox()
     config = await Config.load(loadConfig.root)
     sandbox.stub(config, 'home').value('/Users/jacopastorius')
     fsStub = sandbox.stub(fs, 'existsSync')
@@ -24,6 +25,7 @@ describe('run', () => {
 
   afterEach(() => {
     sandbox.restore()
+    childProcessStub.restore()
   })
 
   it('opens the current directory if no name is specified', () => {


### PR DESCRIPTION
Add `git:config` command to set a repository's local git user config with a specified rcm tag, based on [rcm](https://github.com/thoughtbot/rcm) tag conventions in https://github.com/chrislopresto/dotfiles

**Usage**

```sh
➜  clo git:config -h
Commands for git config

USAGE
  $ clo git:config

OPTIONS
  -h, --help                      show CLI help
  -s, --signingKey=personal|work  (required) rcm tag to use for signingkey

EXAMPLES
  $ clo git:config --signingKey=personal
  $ clo git:config -s work
```