### PR TITLE
feat: Add ktype command

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ USAGE
 * [`clo echo [TEXT]`](#clo-echo-text)
 * [`clo git:config`](#clo-gitconfig)
 * [`clo help [COMMAND]`](#clo-help-command)
+* [`clo ktype [THEME]`](#clo-ktype-theme)
 * [`clo vs [NAME]`](#clo-vs-name)
 
 ## `clo echo [TEXT]`
@@ -44,7 +45,8 @@ USAGE
 
 OPTIONS
   -f, --font=font
-  -h, --help       show CLI help
+  -g, --gradient=gradient
+  -h, --help               show CLI help
 ```
 
 _See code: [src/commands/echo.ts](https://github.com/chrislopresto/clo/blob/v0.0.0/src/commands/echo.ts)_
@@ -84,6 +86,20 @@ OPTIONS
 ```
 
 _See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v2.1.4/src/commands/help.ts)_
+
+## `clo ktype [THEME]`
+
+describe the command here
+
+```
+USAGE
+  $ clo ktype [THEME]
+
+OPTIONS
+  -h, --help  show CLI help
+```
+
+_See code: [src/commands/ktype.ts](https://github.com/chrislopresto/clo/blob/v0.0.0/src/commands/ktype.ts)_
 
 ## `clo vs [NAME]`
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@oclif/config": "^1",
     "@oclif/plugin-help": "^2",
     "chalk": "^2.4.1",
+    "cli-ux": "^4.9.3",
     "figlet": "^1.2.1",
     "gradient-string": "^1.2.0",
     "tslib": "^1"

--- a/src/commands/ktype.ts
+++ b/src/commands/ktype.ts
@@ -1,0 +1,50 @@
+import {Command, flags} from '@oclif/command'
+import {execSync} from 'child_process'
+import cli from 'cli-ux'
+import * as fs from 'fs'
+import * as path from 'path'
+
+const KTYPE_DELAY_SECONDS = 2
+const KTYPE_DELAY_MS = KTYPE_DELAY_SECONDS * 1000
+const KTYPE_THEME_PATH = 'Dropbox (Personal)/ktype/'
+const KTYPE_THEME_FILENAME_SUFFIX = '-kiibohd.dfu.bin'
+
+export default class Ktype extends Command {
+  static description = 'Flash the K-Type keyboard firmware with a new lighting theme. NOTE: dfu-util must be installed.'
+
+  static flags = {
+    help: flags.help({char: 'h'}),
+  }
+
+  static args = [{name: 'theme'}]
+
+  async run() {
+    let {args} = this.parse(Ktype)
+    let {theme} = args
+    let themePath = this.themePath(theme)
+
+    if (!this.themeExists(theme)) {
+      return cli.error(`K-Type theme '${theme}' does not exist at '${themePath}'`)
+    }
+
+    cli.action.start(`Giving you ${KTYPE_DELAY_SECONDS} seconds to put the K-Type in flash mode (Fn-ESC)`)
+    await cli.wait(KTYPE_DELAY_MS)
+    cli.action.stop()
+
+    let cmdString = this.cmd(args.theme)
+    this.log(cmdString)
+    execSync(cmdString, {stdio: 'inherit'})
+  }
+
+  private themeExists(theme: string) {
+    return fs.existsSync(this.themePath(theme))
+  }
+
+  private cmd(theme: string) {
+    return `dfu-util -D '${this.themePath(theme)}'`
+  }
+
+  private themePath(theme: string) {
+    return path.join(this.config.home, KTYPE_THEME_PATH, `${theme}${KTYPE_THEME_FILENAME_SUFFIX}`)
+  }
+}

--- a/test/commands/ktype.test.ts
+++ b/test/commands/ktype.test.ts
@@ -1,0 +1,36 @@
+import * as Config from '@oclif/config'
+import {expect} from '@oclif/test'
+import {loadConfig} from '@oclif/test/lib/load-config'
+import * as childProcess from 'child_process'
+import * as fs from 'fs'
+import * as sinon from 'sinon'
+
+import Ktype from '../../src/commands/ktype'
+
+describe('run', () => {
+  let config: Config.IConfig
+  let sandbox: sinon.SinonSandbox
+  let fsStub: sinon.SinonStub
+  let childProcessStub: sinon.SinonStub
+  let cmd: Ktype
+
+  beforeEach(async () => {
+    sandbox = sinon.createSandbox()
+    config = await Config.load(loadConfig.root)
+    sandbox.stub(config, 'home').value('/Users/jacopastorius')
+    fsStub = sandbox.stub(fs, 'existsSync')
+    childProcessStub = sandbox.stub(childProcess, 'execSync')
+    cmd = new Ktype([], config)
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  it('runs the dfu-util command for a theme', async () => {
+    fsStub.withArgs('/Users/jacopastorius/Dropbox (Personal)/ktype/bass-kiibohd.dfu.bin').returns(true)
+    cmd.argv = ['bass']
+    await cmd.run()
+    expect(childProcessStub.calledOnce).equal(true)
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -608,7 +608,7 @@ clean-stack@^2.0.0:
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.0.0.tgz#301bfa9e8dd2d3d984c0e542f7aa67b996f63e0a"
   integrity sha512-VEoL9Qh7I8s8iHnV53DaeWSt8NJ0g3khMfK6NiCPB7H657juhro+cSw2O88uo3bo0c0X5usamtXk0/Of0wXa5A==
 
-cli-ux@^4.9.0:
+cli-ux@^4.9.0, cli-ux@^4.9.3:
   version "4.9.3"
   resolved "https://registry.yarnpkg.com/cli-ux/-/cli-ux-4.9.3.tgz#4c3e070c1ea23eef010bbdb041192e0661be84ce"
   integrity sha512-/1owvF0SZ5Gn54cgrikJ0QskgTzeg30HGjkmjFoaHDJzAqFpuX1DBpFR8aLvsE1J5s9MgeYRENQK4BFwOag5VA==


### PR DESCRIPTION
Add `ktype` command to flash K-Type keyboard firmware with new light "theme"

```sh
➜ clo ktype -h
Flash the K-Type keyboard firmware with a new lighting theme. NOTE: dfu-util must be installed.

USAGE
  $ clo ktype [THEME]

OPTIONS
  -h, --help  show CLI help
```